### PR TITLE
Fix TransitionSwitch prevValue type error

### DIFF
--- a/.changeset/pink-penguins-drop.md
+++ b/.changeset/pink-penguins-drop.md
@@ -1,0 +1,5 @@
+---
+'react-transition-switch': patch
+---
+
+Fix TransitionSwitch prevValue type error

--- a/packages/react-transition-switch/src/TransitionSwitch.tsx
+++ b/packages/react-transition-switch/src/TransitionSwitch.tsx
@@ -58,16 +58,13 @@ export const TransitionSwitch = forwardRef<
     const [directionalValue, setDirectionalValue] = useState(value);
     const [direction, setDirection] = useState<TransitionSwitchDirection>();
 
-    const prevValue = useRef<typeof value>();
+    const prevValue = useRef<typeof value>(null);
     const innerRef = useRef<HTMLDivElement>(null);
     useImperativeHandle(ref, () => innerRef.current!, []);
 
     useEffect(() => {
       if (!directional) return;
-      if (
-        typeof prevValue.current === 'undefined' ||
-        prevValue.current === value
-      ) {
+      if (prevValue.current === null || prevValue.current === value) {
         prevValue.current = value;
         return;
       }


### PR DESCRIPTION
Use `null` instead of undefined as the initial value of `prevValue`, fixing a type error which caused the build to fail.