### PR TITLE
Move ESLint & tsconfig packages to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.11",
+    "@react-transition-switch/eslint-config": "workspace:*",
+    "@react-transition-switch/tsconfig": "workspace:*",
     "prettier": "^3.4.2",
     "turbo": "^2.3.3",
     "typescript": "^5.7.2"

--- a/packages/react-transition-switch/package.json
+++ b/packages/react-transition-switch/package.json
@@ -55,8 +55,6 @@
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.17.2",
-    "@react-transition-switch/eslint-config": "workspace:*",
-    "@react-transition-switch/tsconfig": "workspace:*",
     "@types/node": "^22.10.5",
     "@types/react": "^19.0.3",
     "@types/react-dom": "^19.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
       '@changesets/cli':
         specifier: ^2.27.11
         version: 2.27.11
+      '@react-transition-switch/eslint-config':
+        specifier: workspace:*
+        version: link:packages/eslint-config
+      '@react-transition-switch/tsconfig':
+        specifier: workspace:*
+        version: link:packages/tsconfig
       prettier:
         specifier: ^3.4.2
         version: 3.4.2
@@ -193,12 +199,6 @@ importers:
       '@arethetypeswrong/cli':
         specifier: ^0.17.2
         version: 0.17.2
-      '@react-transition-switch/eslint-config':
-        specifier: workspace:*
-        version: link:../eslint-config
-      '@react-transition-switch/tsconfig':
-        specifier: workspace:*
-        version: link:../tsconfig
       '@types/node':
         specifier: ^22.10.5
         version: 22.10.5


### PR DESCRIPTION
Remove workspace packages (ESLint config and tsconfig) from `react-transition-switch` devDependencies and instead add them to the root package.json.